### PR TITLE
fix: Change interest tags layout from 5 to 4 columns

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -1117,7 +1117,7 @@
 
 .interest-tags {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    grid-template-columns: repeat(4, 1fr);
     gap: calc(var(--spacing-unit) * 0.8);
     justify-items: start;
 }
@@ -1422,7 +1422,7 @@
 /* モバイル対応 */
 @media (max-width: 768px) {
     .interest-tags {
-        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+        grid-template-columns: repeat(2, 1fr);
     }
     
     .interest-tag {


### PR DESCRIPTION
## Summary
- Changed the interest tags grid layout from 5 columns to 4 columns to prevent text overflow
- Updated grid-template-columns from `repeat(auto-fit, minmax(180px, 1fr))` to `repeat(4, 1fr)`
- Modified mobile responsive layout to use 2 columns instead of auto-fit for better mobile UX

## Test plan
- [x] Verify layout displays 4 columns on desktop
- [x] Test mobile responsive behavior with 2 columns
- [x] Confirm text no longer overflows button boundaries
- [x] Check visual consistency across different screen sizes

🤖 Generated with [Claude Code](https://claude.ai/code)