### PR TITLE
fix: Resolve interest tag overflow and implement blue color scheme

### DIFF
--- a/assets/css/animations.css
+++ b/assets/css/animations.css
@@ -49,11 +49,11 @@
 @keyframes breathing {
     0%, 100% {
         transform: scale(1);
-        box-shadow: 0 0 0 0 rgba(0, 212, 170, 0.7);
+        box-shadow: 0 0 0 0 rgba(30, 58, 138, 0.7);
     }
     50% {
         transform: scale(1.1);
-        box-shadow: 0 0 0 4px rgba(0, 212, 170, 0.2);
+        box-shadow: 0 0 0 4px rgba(30, 58, 138, 0.2);
     }
 }
 
@@ -285,7 +285,7 @@
 
 .project-card:hover {
     transform: translateY(-8px);
-    box-shadow: 0 12px 24px rgba(0, 212, 170, 0.2);
+    box-shadow: 0 12px 24px rgba(30, 58, 138, 0.2);
 }
 
 .strength-item {
@@ -294,7 +294,7 @@
 
 .strength-item:hover {
     transform: translateY(-3px);
-    box-shadow: 0 8px 16px rgba(0, 212, 170, 0.1);
+    box-shadow: 0 8px 16px rgba(30, 58, 138, 0.1);
 }
 
 .workflow-step {
@@ -329,7 +329,7 @@
 
 .btn:hover {
     transform: scale(1.05);
-    box-shadow: 0 5px 15px rgba(0, 212, 170, 0.3);
+    box-shadow: 0 5px 15px rgba(30, 58, 138, 0.3);
 }
 
 /* Form Animations */
@@ -389,7 +389,7 @@
     left: -100%;
     width: 100%;
     height: 100%;
-    background: linear-gradient(90deg, transparent, rgba(0, 212, 170, 0.1), transparent);
+    background: linear-gradient(90deg, transparent, rgba(30, 58, 138, 0.1), transparent);
     transition: left 0.3s ease;
 }
 
@@ -446,7 +446,7 @@
 .social-link:hover {
     transform: translateX(5px);
     border-color: var(--accent-primary);
-    background-color: rgba(0, 212, 170, 0.1);
+    background-color: rgba(30, 58, 138, 0.1);
 }
 
 /* Header Animation on Scroll */
@@ -538,12 +538,12 @@
 
 /* Glowing Effect */
 .glow {
-    box-shadow: 0 0 20px rgba(0, 212, 170, 0.6);
+    box-shadow: 0 0 20px rgba(30, 58, 138, 0.6);
     transition: box-shadow var(--transition-speed) ease;
 }
 
 .glow:hover {
-    box-shadow: 0 0 30px rgba(0, 212, 170, 0.8);
+    box-shadow: 0 0 30px rgba(30, 58, 138, 0.8);
 }
 
 /* About Me Timeline Animations */

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -261,7 +261,7 @@
 
 .project-github-btn:hover {
     transform: scale(1.05);
-    box-shadow: 0 4px 12px rgba(0, 212, 170, 0.3);
+    box-shadow: 0 4px 12px rgba(30, 58, 138, 0.3);
 }
 
 .github-icon {
@@ -576,7 +576,7 @@
     right: 0;
     bottom: 0;
     background: 
-        radial-gradient(circle at 20% 80%, rgba(0, 212, 170, 0.1) 0%, transparent 50%),
+        radial-gradient(circle at 20% 80%, rgba(30, 58, 138, 0.1) 0%, transparent 50%),
         radial-gradient(circle at 80% 20%, rgba(0, 102, 204, 0.1) 0%, transparent 50%);
     pointer-events: none;
     z-index: 1;
@@ -646,7 +646,7 @@
     border: 2px solid var(--accent-primary);
     box-shadow: 
         0 10px 30px rgba(0, 0, 0, 0.15),
-        0 0 0 1px rgba(0, 212, 170, 0.1),
+        0 0 0 1px rgba(30, 58, 138, 0.1),
         inset 0 1px 0 rgba(255, 255, 255, 0.1);
     display: block !important;
     visibility: visible !important;
@@ -711,7 +711,7 @@
 .form-group textarea:focus {
     outline: none;
     border-color: var(--accent-primary);
-    box-shadow: 0 0 0 2px rgba(0, 212, 170, 0.1);
+    box-shadow: 0 0 0 2px rgba(30, 58, 138, 0.1);
 }
 
 .form-group select {
@@ -746,7 +746,7 @@
 
 .contact-btn:hover {
     transform: translateY(-1px);
-    box-shadow: 0 4px 15px rgba(0, 212, 170, 0.2);
+    box-shadow: 0 4px 15px rgba(30, 58, 138, 0.2);
 }
 
 .contact-btn:active {
@@ -768,7 +768,7 @@
     border: 2px solid var(--accent-primary);
     box-shadow: 
         0 8px 25px rgba(0, 0, 0, 0.12),
-        0 0 0 1px rgba(0, 212, 170, 0.1);
+        0 0 0 1px rgba(30, 58, 138, 0.1);
     position: relative;
     overflow: hidden;
 }
@@ -799,7 +799,7 @@
 .contact-item:hover {
     transform: translateY(-1px);
     border-color: var(--accent-primary);
-    box-shadow: 0 2px 8px rgba(0, 212, 170, 0.1);
+    box-shadow: 0 2px 8px rgba(30, 58, 138, 0.1);
 }
 
 .contact-item:last-child {
@@ -958,7 +958,7 @@
     right: 0;
     bottom: 0;
     background: 
-        radial-gradient(circle at 70% 30%, rgba(0, 212, 170, 0.1) 0%, transparent 50%),
+        radial-gradient(circle at 70% 30%, rgba(30, 58, 138, 0.1) 0%, transparent 50%),
         radial-gradient(circle at 30% 70%, rgba(0, 102, 204, 0.05) 0%, transparent 50%);
     pointer-events: none;
     z-index: 1;
@@ -1109,7 +1109,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background: radial-gradient(circle at 70% 30%, rgba(0, 212, 170, 0.1) 0%, transparent 50%);
+    background: radial-gradient(circle at 70% 30%, rgba(30, 58, 138, 0.1) 0%, transparent 50%);
     pointer-events: none;
     z-index: 2;
 }
@@ -1187,7 +1187,7 @@
     border-radius: 50%;
     position: relative;
     animation: breathing 3s ease-in-out infinite;
-    box-shadow: 0 0 0 0 rgba(0, 212, 170, 0.7);
+    box-shadow: 0 0 0 0 rgba(30, 58, 138, 0.7);
 }
 
 .status-dot::before {
@@ -1199,7 +1199,7 @@
     height: 12px;
     border-radius: 50%;
     background: transparent;
-    border: 2px solid rgba(0, 212, 170, 0.3);
+    border: 2px solid rgba(30, 58, 138, 0.3);
     animation: ripple 3s ease-in-out infinite;
 }
 
@@ -1283,10 +1283,10 @@
 }
 
 .interest-tags {
-    display: grid !important;
-    grid-template-columns: repeat(auto-fit, minmax(160px, max-content)) !important;
+    display: flex !important;
+    flex-wrap: wrap !important;
     gap: calc(var(--spacing-unit) * 0.8);
-    justify-content: start;
+    justify-content: flex-start;
     max-width: 100% !important;
 }
 
@@ -1300,22 +1300,18 @@
     transition: all var(--transition-speed) ease;
     text-align: center;
     white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    min-width: 120px;
-    max-width: 220px;
     position: relative;
     cursor: pointer;
     box-sizing: border-box;
-    width: fit-content;
-    justify-self: center;
+    width: auto;
+    flex-shrink: 0;
 }
 
 .interest-tag:hover {
     background: var(--accent-primary);
     color: var(--primary-bg);
     transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(0, 212, 170, 0.3);
+    box-shadow: 0 4px 12px rgba(30, 58, 138, 0.3);
 }
 
 /* おしゃれなツールチップ機能 */
@@ -1331,14 +1327,14 @@
     top: -10px;
     right: -10px;
     transform: scale(0) rotate(45deg);
-    background: linear-gradient(135deg, #00d4aa, #00b894);
+    background: linear-gradient(135deg, #1e3a8a, #3b82f6);
     color: white;
     padding: calc(var(--spacing-unit) * 0.6) calc(var(--spacing-unit) * 0.8);
     border-radius: 50%;
     font-size: 1.2rem;
     font-weight: 700;
     white-space: nowrap;
-    box-shadow: 0 8px 25px rgba(0, 212, 170, 0.4), 0 0 0 3px rgba(255, 255, 255, 0.1);
+    box-shadow: 0 8px 25px rgba(30, 58, 138, 0.4), 0 0 0 3px rgba(255, 255, 255, 0.1);
     opacity: 0;
     pointer-events: none;
     transition: all 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55);
@@ -1359,10 +1355,10 @@
 
 @keyframes pulse-article {
     0%, 70%, 100% {
-        box-shadow: 0 4px 12px rgba(0, 212, 170, 0.3);
+        box-shadow: 0 4px 12px rgba(30, 58, 138, 0.3);
     }
     35% {
-        box-shadow: 0 4px 20px rgba(0, 212, 170, 0.6), 0 0 0 4px rgba(0, 212, 170, 0.2);
+        box-shadow: 0 4px 20px rgba(30, 58, 138, 0.6), 0 0 0 4px rgba(30, 58, 138, 0.2);
     }
 }
 
@@ -1393,7 +1389,7 @@
 /* ホバー時にパルスアニメーションを停止 */
 .interest-tag.has-article:hover {
     animation: none;
-    box-shadow: 0 6px 20px rgba(0, 212, 170, 0.4);
+    box-shadow: 0 6px 20px rgba(30, 58, 138, 0.4);
     transform: translateY(-3px) scale(1.05);
 }
 
@@ -1416,8 +1412,8 @@
 .skill-item:hover {
     transform: translateY(-2px);
     border-color: var(--accent-primary);
-    background-color: rgba(0, 212, 170, 0.1);
-    box-shadow: 0 4px 12px rgba(0, 212, 170, 0.2);
+    background-color: rgba(30, 58, 138, 0.1);
+    box-shadow: 0 4px 12px rgba(30, 58, 138, 0.2);
     color: var(--accent-primary);
 }
 
@@ -1591,44 +1587,34 @@
     }
 }
 
-/* レスポンシブ対応 - 柔軟なグリッドシステム */
+/* レスポンシブ対応 - Flexboxレイアウト */
 @media (max-width: 480px) {
     .interest-tags {
-        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)) !important;
-        gap: calc(var(--spacing-unit) * 0.6);
         justify-content: center;
+        gap: calc(var(--spacing-unit) * 0.6);
     }
     
     .interest-tag {
-        min-width: 140px;
-        max-width: 200px;
         font-size: 0.8rem;
+        padding: calc(var(--spacing-unit) * 0.5) calc(var(--spacing-unit) * 0.8);
     }
 }
 
 @media (min-width: 481px) and (max-width: 768px) {
     .interest-tags {
-        grid-template-columns: repeat(auto-fit, minmax(150px, max-content)) !important;
         justify-content: center;
-    }
-    
-    .interest-tag {
-        min-width: 150px;
-        max-width: 200px;
     }
 }
 
 @media (min-width: 769px) and (max-width: 1024px) {
     .interest-tags {
-        grid-template-columns: repeat(auto-fit, minmax(160px, max-content)) !important;
-        justify-content: start;
+        justify-content: flex-start;
     }
 }
 
 @media (min-width: 1025px) {
     .interest-tags {
-        grid-template-columns: repeat(auto-fit, minmax(160px, max-content)) !important;
-        justify-content: start;
+        justify-content: flex-start;
     }
 }
 
@@ -1658,7 +1644,7 @@
 
 .profile-cta-btn:hover {
     transform: translateY(-2px) scale(1.05);
-    box-shadow: 0 8px 25px rgba(0, 212, 170, 0.3);
+    box-shadow: 0 8px 25px rgba(30, 58, 138, 0.3);
     color: var(--primary-bg);
 }
 

--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -5,9 +5,9 @@
   --secondary-bg: #2d2d2d;
   --text-primary: #ffffff;
   --text-secondary: #b0b0b0;
-  --accent-primary: #00d4aa;
-  --accent-secondary: #0066cc;
-  --hover-color: #00b894;
+  --accent-primary: #1e3a8a;
+  --accent-secondary: #3b82f6;
+  --hover-color: #3b82f6;
   --border-color: #404040;
 
   /* Typography */

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -107,7 +107,7 @@ function loadSkillsData() {
                 
                 item.addEventListener('mouseenter', function() {
                     console.log('Mouse entered:', this.textContent);
-                    this.style.backgroundColor = 'rgba(0, 212, 170, 0.2)';
+                    this.style.backgroundColor = 'rgba(30, 58, 138, 0.2)';
                     this.style.transform = 'translateY(-3px) scale(1.02)';
                 });
                 
@@ -491,7 +491,7 @@ function initSkillTooltips() {
         font-size: 13px !important;
         font-weight: 500 !important;
         max-width: 280px !important;
-        box-shadow: 0 12px 28px rgba(0,0,0,0.3), 0 0 0 1px rgba(0, 212, 170, 0.4) !important;
+        box-shadow: 0 12px 28px rgba(0,0,0,0.3), 0 0 0 1px rgba(30, 58, 138, 0.4) !important;
         border: none !important;
         opacity: 0;
         pointer-events: auto;


### PR DESCRIPTION
## Summary
この修正により、ヒーローページが55点の状態から改善され、文字の表示問題と色合いの統一性が解決されます。

## Changes Made
### 🔧 Interest Tag Text Overflow Fix
- CSS GridからFlexboxレイアウトに変更
- `max-width: 220px` 制約を削除
- "🏅 スペシャルオリンピックス"と"🏀 FIDバスケットボール指導"の文字切れを解決

### 🎨 Color Scheme Update (Green → Blue)
- `--accent-primary`: #00d4aa → #1e3a8a (深い青)
- `--accent-secondary`: #0066cc → #3b82f6 (明るい青)  
- `--hover-color`: #00b894 → #3b82f6 (青)
- すべてのハードコード色参照を更新

### 📱 Responsive Behavior Maintained
- レスポンシブ対応を維持
- 全画面サイズでの適切な表示を確保

## Test Plan
- [x] 興味タグの文字が完全に表示されることを確認
- [x] レスポンシブ動作が正常に機能することを確認  
- [x] 青色テーマが全体に適用されていることを確認
- [x] ホバーエフェクトが適切に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)